### PR TITLE
Replace dialog with dynamic card

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ iceConfig: # Remove if you don't want to use ICE
 ```
 
 ## Wiki
-You can find more information on the [SIP-HASS Docs](tech7fox.github.io/sip-hass-docs/).
+You can find more information on the [SIP-HASS Docs](https://tech7fox.github.io/sip-hass-docs/).
 
 ## Troubleshooting
 Most problems is because your PBX server is not configured correct, or your certificate is not accepted.

--- a/README.md
+++ b/README.md
@@ -128,12 +128,13 @@ iceConfig: # Remove if you don't want to use ICE
   rtcpMuxPolicy: require
 ```
 
+## Wiki
+You can find more information on the [SIP-HASS Docs](tech7fox.github.io/sip-hass-docs/).
+
 ## Troubleshooting
 Most problems is because your PBX server is not configured correct, or your certificate is not accepted.
 To accept the certificate for Asterisk/FreePBX go to `https://<host>:8089/ws` and click continue.
-To see how to configure FreePBX go to: https://github.com/TECH7Fox/sip-hass-card/wiki/Setup-FreePBX
-
-[Here is the main wiki](https://github.com/TECH7Fox/asterisk-hass-addons/wiki)
+To see how to configure FreePBX go to the [FreePBX guide](https://tech7fox.github.io/sip-hass-docs/docs/card/guides/freepbx).
 
 Android companion app 2022.2 required for speaker + audio permissions.
 

--- a/src/sipjs-card.ts
+++ b/src/sipjs-card.ts
@@ -305,6 +305,7 @@ class SipJsCard extends LitElement {
     render() {
         return html`
             <audio id="toneAudio" style="display:none" loop controls></audio>
+            <audio id="remoteAudio" style="display:none"></audio>
             ${this.popup ? html`
                 <style>
                     ha-icon-button {
@@ -336,7 +337,6 @@ class SipJsCard extends LitElement {
                     ` : html`
                         <div id="audioVisualizer" style="display:${this.config.video ? "none": "flex"}"></div>
                         <video poster="noposter" style="display:${this.config.video ? "block": "none"}" playsinline id="remoteVideo"></video>
-                        <audio id="remoteAudio" style="display:none"></audio>
                     `}
                     <div class="box">
                         <div class="row">
@@ -394,8 +394,8 @@ class SipJsCard extends LitElement {
                     </div>
                 </div>
             ` : html`
-                <ha-card @click="${this.openPopup}">
-                    <h1 class="card-header">
+                <ha-card>
+                    <h1 class="card-header" @click="${this.openPopup}">
                         <span id="title" class="name">${this.getTitle()}</span>
                         <span id="extension" style="color: ${this.getConnectionCSS()};">${this.user_extension}</span>
                     </h1>
@@ -430,19 +430,41 @@ class SipJsCard extends LitElement {
                         })}
 
                         ${this.config.custom ?
-                            this.config.custom.map((custom: { entity: string | number; icon: any; name: any; number: any; camera: any; }) => {
+                            this.config.custom.map((custom: { entity: string | number; icon: any; name: any; number: any; camera: any; edit: any;}) => {
                                 var stateObj = this.hass.states[custom.entity];
-                                return html`
-                                    <div class="flex">
-                                        <state-badge
-                                            .stateObj=${stateObj}
-                                            .overrideIcon=${custom.icon}
-                                            .stateColor=${this.config.state_color}
-                                        ></state-badge>
-                                        <div class="info">${custom.name}</div>
-                                        <mwc-button @click="${() => this._call(custom.number, custom.camera)}">CALL</mwc-button>
-                                    </div>
-                                `;
+                                var nameid = "custom_" + custom.name.toLowerCase().split(' ').join('_');;
+                                if (custom.edit){
+                                    return html`
+                                        <div class="flex">
+                                            <state-badge
+                                                .stateObj=${stateObj}
+                                                .overrideIcon=${custom.icon}
+                                                .stateColor=${this.config.state_color}
+                                            ></state-badge>
+                                            <ha-textfield
+                                                id="${nameid}"
+                                                .value=${custom.number}
+                                                .label=${custom.name}
+                                                type="text"
+                                                .inputmode="text"
+                                                style="width:100%;"
+                                            ></ha-textfield>
+                                            <mwc-button @click="${() => this._custom_call(nameid, custom.camera)}">CALL</mwc-button>
+                                        </div>
+                                    `;
+                                } else {
+                                    return html`
+                                        <div class="flex">
+                                            <state-badge
+                                                .stateObj=${stateObj}
+                                                .overrideIcon=${custom.icon}
+                                                .stateColor=${this.config.state_color}
+                                            ></state-badge>
+                                            <div class="info">${custom.name}</div>
+                                            <mwc-button @click="${() => this._call(custom.number, custom.camera)}">CALL</mwc-button>
+                                        </div>
+                                    `;
+                                }
                             }) : ""
                         }
 
@@ -541,12 +563,20 @@ class SipJsCard extends LitElement {
     }
 
     async _call(extension: string | null, camera: any) {
+        this.openPopup();
         this.ring("ringbacktone");
         this.setCallStatus("Calling...");
         this.currentCamera = (camera ? camera : undefined);
         if (this.sipPhone) {
             this.sipPhone.call("sip:" + extension + "@" + this.config.server, this.sipCallOptions);
         }
+    }
+
+    async _custom_call(nameid: string | null, camera: any) {
+        console.log(this.renderRoot.querySelector('#' + nameid));
+        var number = this.renderRoot.querySelector('#' + nameid).value;
+        console.log("Trying to custom call this: " + number);
+        this._call(number, camera);
     }
 
     async _answer() {

--- a/src/sipjs-card.ts
+++ b/src/sipjs-card.ts
@@ -165,7 +165,7 @@ class SipJsCard extends LitElement {
                 align-items: center;
             }
             .extension {
-                color: gray;
+                color: var(--mdc-theme-error, #db4437);
             }
             ha-camera-stream {
                 height: auto;
@@ -222,6 +222,9 @@ class SipJsCard extends LitElement {
 
             #audioVisualizer {
                 position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
                 white-space: nowrap;
             }
 

--- a/src/sipjs-card.ts
+++ b/src/sipjs-card.ts
@@ -31,6 +31,7 @@ class SipJsCard extends LitElement {
     callStatus: string = "Idle";
     user_extension: string = "None";
     card_title: string = "Unknown";
+    connected: boolean = false;
 
     constructor() {
         super();
@@ -163,9 +164,6 @@ class SipJsCard extends LitElement {
                 margin-right: 8px;
                 display: flex;
                 align-items: center;
-            }
-            .extension {
-                color: var(--mdc-theme-error, #db4437);
             }
             ha-camera-stream {
                 height: auto;
@@ -398,7 +396,7 @@ class SipJsCard extends LitElement {
                 <ha-card @click="${this.openPopup}">
                     <h1 class="card-header">
                         <span id="title" class="name">${this.getTitle()}</span>
-                        <span id="extension" class="extension">${this.user_extension}</span>
+                        <span id="extension" style="color: ${this.getConnectionCSS()};">${this.user_extension}</span>
                     </h1>
                     <div class="wrapper">
                         ${(this.error !== null) ? html`
@@ -530,6 +528,14 @@ class SipJsCard extends LitElement {
             return this.user.name;
         } else {
             return "Undefined";
+        }
+    }
+
+    private getConnectionCSS() {
+        if (this.connected) {
+            return 'gray'
+        } else {
+            return 'var(--mdc-theme-error, #db4437)'
         }
     }
 
@@ -676,15 +682,18 @@ class SipJsCard extends LitElement {
 
         this.sipPhone?.on("registered", () => {
             console.log('SIP-Card Registered with SIP Server');
-            this.renderRoot.querySelector('.extension').style.color = 'gray';
+            this.connected = true;
+            // this.renderRoot.querySelector('.extension').style.color = 'gray';
         });
         this.sipPhone?.on("unregistered", () => {
             console.log('SIP-Card Unregistered with SIP Server');
-            this.renderRoot.querySelector('.extension').style.color = 'var(--mdc-theme-primary, #03a9f4)';
+            this.connected = false;
+            // this.renderRoot.querySelector('.extension').style.color = 'var(--mdc-theme-primary, #03a9f4)';
         });
         this.sipPhone?.on("registrationFailed", () => {
             console.log('SIP-Card Failed Registeration with SIP Server');
-            this.renderRoot.querySelector('.extension').style.color = 'var(--mdc-theme-error, #db4437)';
+            this.connected = false;
+            // this.renderRoot.querySelector('.extension').style.color = 'var(--mdc-theme-error, #db4437)';
         });
         this.sipPhone?.on("newRTCSession", (event: RTCSessionEvent) => {
             if (this.sipPhoneSession !== null ) {

--- a/src/sipjs-card.ts
+++ b/src/sipjs-card.ts
@@ -219,11 +219,12 @@ class SipJsCard extends LitElement {
             }
 
             #audioVisualizer {
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
+                min-height: 20em;
                 white-space: nowrap;
+                align-items: center;
+                display: flex;
+                justify-content: center;
+                background: var(--card-background-color);
             }
 
             #audioVisualizer div {
@@ -333,8 +334,8 @@ class SipJsCard extends LitElement {
                             .stateObj=${this.hass.states[this.currentCamera]}
                         ></ha-camera-stream>
                     ` : html`
-                        <div id="audioVisualizer"></div>
-                        <video poster="noposter" playsinline id="remoteVideo"></video>
+                        <div id="audioVisualizer" style="display:${this.config.video ? "none": "flex"}"></div>
+                        <video poster="noposter" style="display:${this.config.video ? "block": "none"}" playsinline id="remoteVideo"></video>
                         <audio id="remoteAudio" style="display:none"></audio>
                     `}
                     <div class="box">
@@ -352,7 +353,7 @@ class SipJsCard extends LitElement {
                                 @click="${this._toggleMuteAudio}"
                                 ><ha-icon id="muteaudio-icon" icon="hass:microphone"></ha-icon>
                             </ha-icon-button>
-                            <ha-icon-button
+                            <ha-icon-button style="display:${this.config.video ? "block": "none"}"
                                 .label=${"Mute video"}
                                 @click="${this._toggleMuteVideo}"
                                 ><ha-icon id="mutevideo-icon" icon="${this.config.video ? "hass:video" : "hass:video-off"}"></ha-icon>

--- a/src/sipjs-card.ts
+++ b/src/sipjs-card.ts
@@ -222,9 +222,6 @@ class SipJsCard extends LitElement {
 
             #audioVisualizer {
                 position: absolute;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
                 white-space: nowrap;
             }
 
@@ -305,11 +302,8 @@ class SipJsCard extends LitElement {
 
     render() {
         return html`
-            <audio id="remoteAudio" style="display:none"></audio>
             <audio id="toneAudio" style="display:none" loop controls></audio>
             ${this.popup ? html`
-                <audio id="remoteAudio" style="display:none"></audio>
-                <audio id="toneAudio" style="display:none" loop controls></audio>
                 <style>
                     ha-icon-button {
                         --mdc-icon-button-size: ${this.config.button_size ? unsafeCSS(this.config.button_size) : css`48`}px;
@@ -340,6 +334,7 @@ class SipJsCard extends LitElement {
                     ` : html`
                         <div id="audioVisualizer"></div>
                         <video poster="noposter" playsinline id="remoteVideo"></video>
+                        <audio id="remoteAudio" style="display:none"></audio>
                     `}
                     <div class="box">
                         <div class="row">
@@ -397,8 +392,6 @@ class SipJsCard extends LitElement {
                     </div>
                 </div>
             ` : html`
-                <audio id="remoteAudio" style="display:none"></audio>
-                <audio id="toneAudio" style="display:none" loop controls></audio>
                 <ha-card @click="${this.openPopup}">
                     <h1 class="card-header">
                         <span id="title" class="name">${this.getTitle()}</span>


### PR DESCRIPTION
The popup window had issues when used with other cards, so I replaced it.
Now the card changes dynamically based on events which makes it simpler to use.

Keep in mind that this is a major change, so I would recommend to check out for any bugs, though on my tests it works great.

Updates:
 - Replace popup window with dynamic card (#47)
 - Hide video window and button if the user has disabled it
 - Input text for custom entities to dial any number (#69)