### PR TITLE
Add prefix option for the wss

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -258,6 +258,12 @@ class SipJsCardEditor extends LitElement {
                     @value-changed="${this._valueChanged}"
                 ></paper-input>
                 <paper-input
+                    label="prefix"
+                    .value="${this._config.prefix}"
+                    .configValue="${"prefix"}"
+                    @value-changed="${this._valueChanged}"
+                ></paper-input>                
+                <paper-input
                     label="Custom title"
                     .value="${this._config.custom_title}"
                     .configValue="${"custom_title"}"

--- a/src/sipjs-card.ts
+++ b/src/sipjs-card.ts
@@ -704,7 +704,7 @@ class SipJsCard extends LitElement {
             throw new Error("Person not configured!");
         }
 
-        var socket = new WebSocketInterface("wss://" + this.config.server + ":" + this.config.port + "/ws");
+        var socket = new WebSocketInterface("wss://" + this.config.server + ":" + this.config.port + this.config.prefix + "/ws");
         var configuration = {
             sockets : [ socket ],
             uri     : "sip:" + this.user.extension + "@" + this.config.server,


### PR DESCRIPTION
On my asterisk installation, the wss is positioned behind a proxy and looks like this:  `wss://mydomain.com/api/asterisk/ws`
I need to specify the path of the websocket for this to work.