### PR TITLE
Add support for default microphone device use only

### DIFF
--- a/src/sip-call-dialog.ts
+++ b/src/sip-call-dialog.ts
@@ -57,6 +57,9 @@ class SIPCallDialog extends LitElement {
     @property()
     public config = sipCore.config.popup_config as PopupConfig;
 
+    @property()
+    public useDefaultAudioDevices = sipCore.config.use_default_audio_devices_only
+
     @state()
     private audioVisualizer: AudioVisualizer | undefined;
 
@@ -295,44 +298,46 @@ class SIPCallDialog extends LitElement {
                     <span slot="title" .title="Call">SIP Call Settings</span>
                 </ha-dialog-header>
                 <div tabindex="-1" dialogInitialFocus class="form">
-                    <ha-select
-                        naturalMenuWidth
-                        fixedMenuPosition
-                        icon
-                        label=${"Audio Output"}
-                        .value="${sipCore.currentAudioOutputId}"
-                        @selected=${this.handleAudioOutputChange}
-                        @closed="${(event: { stopPropagation: () => any; }) => event.stopPropagation()}">
-                        ${this.outputDevices.map((device) => html`
-                            <ha-list-item
-                                graphic="icon"
-                                .value="${device.deviceId}"
-                                ?selected=${sipCore.currentAudioOutputId === device.deviceId}>
-                                ${device.label}
-                                <ha-icon slot="graphic" .icon=${"mdi:headphones"}></ha-icon>
-                            </ha-list-item>
-                        `)}
-                        <ha-icon slot="icon" .icon=${"mdi:headphones"}></ha-icon>
-                    </ha-select>
-                    <ha-select
-                        naturalMenuWidth
-                        fixedMenuPosition
-                        icon
-                        label=${"Audio Input"}
-                        .value="${sipCore.currentAudioInputId}"
-                        @selected=${this.handleAudioInputChange}
-                        @closed="${(event: { stopPropagation: () => any; }) => event.stopPropagation()}">
-                        ${this.inputDevices.map((device) => html`
-                            <ha-list-item
-                                graphic="icon"
-                                .value="${device.deviceId}"
-                                ?selected=${sipCore.currentAudioInputId === device.deviceId}>
-                                ${device.label}
-                                <ha-icon slot="graphic" .icon=${"mdi:microphone"}></ha-icon>
-                            </ha-list-item>
-                        `)}
-                        <ha-icon slot="icon" .icon=${"mdi:microphone"}></ha-icon>
-                    </ha-select>
+                    ${ !!this.useDefaultAudioDevices ? "" : html`
+                        <ha-select
+                            naturalMenuWidth
+                            fixedMenuPosition
+                            icon
+                            label=${"Audio Output"}
+                            .value="${sipCore.currentAudioOutputId}"
+                            @selected=${this.handleAudioOutputChange}
+                            @closed="${(event: { stopPropagation: () => any; }) => event.stopPropagation()}">
+                            ${this.outputDevices.map((device) => html`
+                                <ha-list-item
+                                    graphic="icon"
+                                    .value="${device.deviceId}"
+                                    ?selected=${sipCore.currentAudioOutputId === device.deviceId}>
+                                    ${device.label}
+                                    <ha-icon slot="graphic" .icon=${"mdi:headphones"}></ha-icon>
+                                </ha-list-item>
+                            `)}
+                            <ha-icon slot="icon" .icon=${"mdi:headphones"}></ha-icon>
+                        </ha-select>
+                        <ha-select
+                            naturalMenuWidth
+                            fixedMenuPosition
+                            icon
+                            label=${"Audio Input"}
+                            .value="${sipCore.currentAudioInputId}"
+                            @selected=${this.handleAudioInputChange}
+                            @closed="${(event: { stopPropagation: () => any; }) => event.stopPropagation()}">
+                            ${this.inputDevices.map((device) => html`
+                                <ha-list-item
+                                    graphic="icon"
+                                    .value="${device.deviceId}"
+                                    ?selected=${sipCore.currentAudioInputId === device.deviceId}>
+                                    ${device.label}
+                                    <ha-icon slot="graphic" .icon=${"mdi:microphone"}></ha-icon>
+                                </ha-list-item>
+                            `)}
+                            <ha-icon slot="icon" .icon=${"mdi:microphone"}></ha-icon>
+                        </ha-select>` 
+                    } 
                     <ha-settings-row>
                         <span slot="heading">Logged in as ${sipCore.user.ha_username} <span style="color: gray;">(${sipCore.user.extension})</span></span>
                         <span slot="description">The current user used to log in to the SIP server. You can configure users in the sip-config.json file</span> 
@@ -509,8 +514,10 @@ class SIPCallDialog extends LitElement {
     }
 
     async firstUpdated() {
-        this.outputDevices = await sipCore.getAudioDevices(AUDIO_DEVICE_KIND.OUTPUT);
-        this.inputDevices = await sipCore.getAudioDevices(AUDIO_DEVICE_KIND.INPUT);
+        if (!this.useDefaultAudioDevices) {
+            this.outputDevices = await sipCore.getAudioDevices(AUDIO_DEVICE_KIND.OUTPUT);
+            this.inputDevices = await sipCore.getAudioDevices(AUDIO_DEVICE_KIND.INPUT);
+        }
     }
 
     private handleAudioInputChange(event: Event) {

--- a/src/sip-config.json
+++ b/src/sip-config.json
@@ -29,6 +29,7 @@
     ],
     "sip_video": false,
     "auto_answer": false,
+    "use_default_audio_devices_only": false,
     "popup_config": {
         "auto_open": true,
         "large": false,

--- a/src/sip-core.ts
+++ b/src/sip-core.ts
@@ -48,6 +48,7 @@ export interface SIPCoreConfig {
     backup_user: User;
     users: User[];
     auto_answer: boolean;
+    use_default_audio_devices_only: boolean;
     popup_config: Object | null;
     popup_override_component: string | null;
     /** 
@@ -221,7 +222,7 @@ export class SIPCore {
 
         if (this.config.sip_video) {
             // Request permission to use video devices for later use
-            await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+            await navigator.mediaDevices.getUserMedia({ video: true, audio: !this.config.use_default_audio_devices_only });
         }
 
         console.info(`Connecting to ${this.wssUrl}...`);
@@ -470,6 +471,11 @@ export class SIPCore {
 
     /** Returns a list of audio devices of the specified kind */
     async getAudioDevices(audioKind: AUDIO_DEVICE_KIND) {
+        if (!!this.config.use_default_audio_devices_only && audioKind === AUDIO_DEVICE_KIND.INPUT) {
+            console.info("Using default microphone only, returning empty list for audio input devices");
+            return [];
+        }
+
         // first get permission to use audio devices
         await navigator.mediaDevices.getUserMedia({ audio: true });
 
@@ -490,6 +496,14 @@ export class SIPCore {
         console.info(`Setting audio device ${deviceId} (${audioKind})`);
         switch (audioKind) {
             case AUDIO_DEVICE_KIND.INPUT:
+                if (!!this.config.use_default_audio_devices_only) {
+                    console.info("Using default microphone only, ignoring audio input device change");
+                    this.currentAudioInputId = null;
+                    localStorage.removeItem("sipcore-audio-input");
+                    this.triggerUpdate();
+                    return;
+                }
+                
                 try {
                     await navigator.mediaDevices.getUserMedia({
                         audio: {


### PR DESCRIPTION
This optionally removes the feature to allow the user to select input/output devices. Calls to getUserMedia always "capture" the mic which leads to undesirable behaviour on e.g. mobile usage where music playback is stopped when opening HA. This fix ensures this only happens during active calls.