### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   release:
     name: Prepare release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,5 +1,6 @@
 name: Update Docs
 
+permissions: {}
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/TECH7Fox/sip-hass-card/security/code-scanning/3](https://github.com/TECH7Fox/sip-hass-card/security/code-scanning/3)

To resolve the flagged issue, you should add an explicit `permissions` block to the workflow. This can be done either at the root level (applying to all jobs) or within the individual job (only applying to that job). Since the current workflow triggers an external workflow using a curl command with a PAT, it does not require write access to repo contents or other features protected by GITHUB_TOKEN. The best practice is to set `permissions: {}` at the job level or at the root of the workflow, thereby explicitly disabling all default token permissions. This fix requires updating .github/workflows/update-docs.yml, either by inserting the block at the top level (between lines 2 and 3) or inside the job definition (above line 12).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
